### PR TITLE
fix: add keys to reduce argocd drift

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Upload rendered manifests as artifact
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: rendered-manifests
           path: rendered.yaml

--- a/templates/externalsecret.yaml
+++ b/templates/externalsecret.yaml
@@ -19,5 +19,8 @@ spec:
       remoteRef:
         key: {{ $item.remoteKey }}
         property: {{ $item.remoteProperty }}
+        conversionStrategy: Default	
+        decodingStrategy: None	
+        metadataPolicy: None
     {{- end }}
 {{- end }}


### PR DESCRIPTION
Adding a default set of keys to minimize the drift during the ArgoCD deployment of resources. Initial configuration is defined with the default values. 